### PR TITLE
fix error wrapping in main file

### DIFF
--- a/main.go
+++ b/main.go
@@ -89,7 +89,7 @@ func runVulnny() (*sarif.Log, error) {
 	}
 	log, err := sarif.FromResult(res)
 	if err != nil {
-		return nil, fmt.Errorf("failed to convert Result to sarif log: %w", err.Error())
+		return nil, fmt.Errorf("failed to convert Result to sarif log: %w", err)
 	}
 	return log, nil
 }


### PR DESCRIPTION
In the release of v0.0.1 there was an issue of using the `fmt.Errorf("... : %w", err.Error())` which should have been `fmt.Errorf("... : %w", err)`. This PR aims to fix that issue.