### PR TITLE
Fix incorrect help uri from SARIF

### DIFF
--- a/internal/sarif/sarif.go
+++ b/internal/sarif/sarif.go
@@ -58,7 +58,7 @@ func FromResult(r *vulncheck.Result) (*Log, error) {
 		rule := ReportingDescriptor{
 			ID:      ruleID,
 			Name:    "VulnerablePackage",
-			HelpURI: fmt.Sprintf("https://osv.dev/vulnerability/%s", strings.ToLower(v.OSV.ID)),
+			HelpURI: fmt.Sprintf("https://osv.dev/vulnerability/%s", v.OSV.ID),
 			ShortDescription: &MultiFormatMessageString{
 				Text: shortDescription,
 			},


### PR DESCRIPTION
Previously we were making the vulnerability tags lowercase by assuming that the uri strings for the `osv.dev/vulnerability/` would take in lowercase tags as suffix. This assumption was wrong, and the resulting sarif files that were created had incorrect help url since the `osv.dev/vulnerability/GO-2023-1234` is not the same as `osv.dev/vulnerability/go-2023-1234`. This PR fixes this issue.