### PR TITLE
Fix issue with uploading to code scanning

### DIFF
--- a/internal/sarif/spec.go
+++ b/internal/sarif/spec.go
@@ -143,5 +143,5 @@ type Result struct {
 
 type Run struct {
 	Tool    Tool     `json:"tool"`
-	Results []Result `json:"results,omitempty"`
+	Results []Result `json:"results"`
 }


### PR DESCRIPTION
When trying to upload SARIF generated by Vulnny to Code Scanning, it would get rejected if the sarif doesn't contain a result key inside the run array. This happens when the repository being scanned doesn't have any vulnerability.